### PR TITLE
Fixed fluent configuration API

### DIFF
--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>2.0.0</Version>
-    <PackageReleaseNotes>Introduced domain events and hooked into messaging</PackageReleaseNotes>
+    <Version>2.0.1</Version>
+    <PackageReleaseNotes>Fixed the contract for fluent configuration using the implementation instead of the contract.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>True</IsPackable>

--- a/src/Eshopworld.Telemetry/MessagingConfigurationExtensions.cs
+++ b/src/Eshopworld.Telemetry/MessagingConfigurationExtensions.cs
@@ -9,9 +9,9 @@
         /// </summary>
         /// <param name="bb">The <see cref="BigBrother"/> instance we are configuring.</param>
         /// <param name="publisher">The event publisher we are using to send events onto topics.</param>
-        public static void PublishEventsToTopics(this BigBrother bb, IPublishEvents publisher)
+        public static void PublishEventsToTopics(this IBigBrother bb, IPublishEvents publisher)
         {
-            bb.TopicPublisher = publisher;
+            ((BigBrother)bb).TopicPublisher = publisher;
         }
     }
 }

--- a/src/Eshopworld.Telemetry/MessagingConfigurationExtensions.cs
+++ b/src/Eshopworld.Telemetry/MessagingConfigurationExtensions.cs
@@ -12,7 +12,7 @@
         /// <param name="publisher">The event publisher we are using to send events onto topics.</param>
         public static void PublishEventsToTopics(this IBigBrother bb, IPublishEvents publisher)
         {
-            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}"); ;
+            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}");
             bbImpl.TopicPublisher = publisher;
         }
     }

--- a/src/Eshopworld.Telemetry/MessagingConfigurationExtensions.cs
+++ b/src/Eshopworld.Telemetry/MessagingConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Eshopworld.Telemetry
 {
+    using System;
     using Core;
 
     public static class MessagingConfigurationExtensions
@@ -11,7 +12,8 @@
         /// <param name="publisher">The event publisher we are using to send events onto topics.</param>
         public static void PublishEventsToTopics(this IBigBrother bb, IPublishEvents publisher)
         {
-            ((BigBrother)bb).TopicPublisher = publisher;
+            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}"); ;
+            bbImpl.TopicPublisher = publisher;
         }
     }
 }

--- a/src/Eshopworld.Telemetry/TelemetryConfigurationExtensions.cs
+++ b/src/Eshopworld.Telemetry/TelemetryConfigurationExtensions.cs
@@ -1,8 +1,8 @@
 ﻿namespace Eshopworld.Telemetry
 {
+    using Core;
     using System;
     using System.Reactive.Linq;
-    using Core;
 
     /// <summary>
     /// Fluent API extensions for configuring <see cref="BigBrother"/>.
@@ -17,7 +17,8 @@
         /// <returns></returns>
         public static IConfigureSources UseEventSourceSink(this IBigBrother bb)
         {
-            return new EventSourceSink((BigBrother)bb);
+            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}"); ;
+            return new EventSourceSink(bbImpl);
         }
 
         /// <summary>
@@ -27,7 +28,8 @@
         /// <returns></returns>
         public static IConfigureSources UseTraceSink(this IBigBrother bb)
         {
-            return new TraceSink((BigBrother)bb);
+            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}"); ;
+            return new TraceSink(bbImpl);
         }
 
         /// <summary>

--- a/src/Eshopworld.Telemetry/TelemetryConfigurationExtensions.cs
+++ b/src/Eshopworld.Telemetry/TelemetryConfigurationExtensions.cs
@@ -17,7 +17,7 @@
         /// <returns></returns>
         public static IConfigureSources UseEventSourceSink(this IBigBrother bb)
         {
-            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}"); ;
+            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}");
             return new EventSourceSink(bbImpl);
         }
 
@@ -28,7 +28,7 @@
         /// <returns></returns>
         public static IConfigureSources UseTraceSink(this IBigBrother bb)
         {
-            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}"); ;
+            var bbImpl = bb as BigBrother ?? throw new InvalidOperationException($"Couldn't cast this instance of {nameof(IBigBrother)} to a concrete implementation of {nameof(BigBrother)}");
             return new TraceSink(bbImpl);
         }
 

--- a/src/Eshopworld.Telemetry/TelemetryConfigurationExtensions.cs
+++ b/src/Eshopworld.Telemetry/TelemetryConfigurationExtensions.cs
@@ -15,9 +15,9 @@
         /// </summary>
         /// <param name="bb">The <see cref="BigBrother"/> instance we are configuring.</param>
         /// <returns></returns>
-        public static IConfigureSources UseEventSourceSink(this BigBrother bb)
+        public static IConfigureSources UseEventSourceSink(this IBigBrother bb)
         {
-            return new EventSourceSink(bb);
+            return new EventSourceSink((BigBrother)bb);
         }
 
         /// <summary>
@@ -25,9 +25,9 @@
         /// </summary>
         /// <param name="bb">The <see cref="BigBrother"/> instance we are configuring.</param>
         /// <returns></returns>
-        public static IConfigureSources UseTraceSink(this BigBrother bb)
+        public static IConfigureSources UseTraceSink(this IBigBrother bb)
         {
-            return new TraceSink(bb);
+            return new TraceSink((BigBrother)bb);
         }
 
         /// <summary>


### PR DESCRIPTION
The fluent configuration API for telemetry was using the `BigBrother` implementation rather the `IBigBrother` contract,  this PR fixes that.