### PR TITLE
Feature/topic queue names update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+launchSettings\.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
@@ -251,5 +252,3 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
-
-src/Eshopworld\.Telemetry/Properties/launchSettings\.json

--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,5 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+src/Eshopworld\.Telemetry/Properties/launchSettings\.json

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -22,6 +22,18 @@
     using System.Reactive.Subjects;
     using System.Runtime.CompilerServices;
     using Microsoft.Azure.Services.AppAuthentication;
+    public interface IBigBrother
+    {
+        void Publish<T>(T @event, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) where T : TelemetryEvent;
+
+        void Publish(object @event, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1);
+
+        IBigBrother DeveloperMode();
+
+        void Flush();
+
+        IBigBrother UseKusto(string kustoEngineName, string kustoEngineLocation, string kustoDb, string tenantId);
+    }
 
     /// <summary>
     /// Deals with everything that's public in telemetry.
@@ -186,11 +198,11 @@
         }
 
         /// <inheritdoc />
-        public void Publish(
-            TelemetryEvent @event,
+        public void Publish<T>(
+            T @event,
             [CallerMemberName] string callerMemberName = "",
             [CallerFilePath] string callerFilePath = "",
-            [CallerLineNumber] int callerLineNumber = -1)
+            [CallerLineNumber] int callerLineNumber = -1) where T : TelemetryEvent
         {
             if (TopicPublisher != null && @event is DomainEvent)
             {
@@ -203,6 +215,7 @@
                 telemetryEvent.CallerFilePath = callerFilePath;
                 telemetryEvent.CallerLineNumber = callerLineNumber;
             }
+
             if (@event is TimedTelemetryEvent timedEvent)
             {
                 timedEvent.End();
@@ -210,7 +223,7 @@
 
             TelemetryStream.OnNext(@event);
         }
-
+        
         /// <inheritdoc />
         public void Publish(
             object @event,

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -22,18 +22,6 @@
     using System.Reactive.Subjects;
     using System.Runtime.CompilerServices;
     using Microsoft.Azure.Services.AppAuthentication;
-    public interface IBigBrother
-    {
-        void Publish<T>(T @event, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1) where T : TelemetryEvent;
-
-        void Publish(object @event, [CallerMemberName] string callerMemberName = "", [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1);
-
-        IBigBrother DeveloperMode();
-
-        void Flush();
-
-        IBigBrother UseKusto(string kustoEngineName, string kustoEngineLocation, string kustoDb, string tenantId);
-    }
 
     /// <summary>
     /// Deals with everything that's public in telemetry.

--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <PackageReleaseNotes>Added Kusto integration for Telemetry Events.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,7 +10,7 @@
 
     <PackageId>Eshopworld.Telemetry</PackageId>
     <Title>Eshopworld.Telemetry</Title>
-    <Authors>David Rodrigues, Oisin Haken</Authors>
+    <Authors>David Rodrigues, Oisin Haken, David Guerin</Authors>
     <Copyright>Copyright eShopWorld 2018</Copyright>
     <Description>eShopWorld common telemetry application insights</Description>
     <PackageLicenseUrl>https://github.com/eShopWorld/telemetry/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -25,11 +25,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eshopworld.Core" Version="2.0.2" />
+    <PackageReference Include="Eshopworld.Core" Version="2.0.3" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest.NETStandard" Version="4.0.3" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Reactive" Version="4.1.2" />
   </ItemGroup>
 

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherTest.cs
@@ -9,7 +9,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Diagnostics.Tracing.Session;
 using Moq;
 using Xunit;
-using IBigBrother = Eshopworld.Telemetry.IBigBrother;
 
 //ReSharper disable once CheckNamespace
 public class BigBrotherTest

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherTest.cs
@@ -9,6 +9,7 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Diagnostics.Tracing.Session;
 using Moq;
 using Xunit;
+using IBigBrother = Eshopworld.Telemetry.IBigBrother;
 
 //ReSharper disable once CheckNamespace
 public class BigBrotherTest

--- a/src/Tests/Eshopworld.Telemetry.Tests/Eshopworld.Telemetry.Tests.csproj
+++ b/src/Tests/Eshopworld.Telemetry.Tests/Eshopworld.Telemetry.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Eshopworld.Tests.Core" Version="1.0.5" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
-    <PackageReference Include="polly" Version="6.1.0" />
+    <PackageReference Include="polly" Version="6.1.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
This updates the implementation of BB such that a constrained generic is passed in rather than a concrete type of Telemetry Event. This allows us to infer the type of the Domain Event passed in such that the associated topics and queues which are auto created are names based on the child type. 

Constraining the generic to the TelemetryEvent type should provide the same constrains as before but with the benefits of generics the whole way through the call flow.

Note interface needs to be updated before this can be merged in. 

1. Review https://github.com/eShopWorld/core/pull/8
1. Review https://github.com/eShopWorld/messaging/pull/6
1. When both are approved and merged, I'll consume them in here on this PR.