### PR TITLE
Made stock trace simplification safer to use.

### DIFF
--- a/src/Eshopworld.Telemetry/ConvertEvent.cs
+++ b/src/Eshopworld.Telemetry/ConvertEvent.cs
@@ -32,7 +32,7 @@
         public ConvertEvent([NotNull]TFrom @event)
         {
             // mapping checks, blow up on wrong usage
-            if(typeof(TFrom) == typeof(TelemetryEvent) && typeof(TTo) != typeof(EventTelemetry))
+            if (typeof(TFrom) == typeof(TelemetryEvent) && typeof(TTo) != typeof(EventTelemetry))
                 throw new InvalidOperationException($"You can only convert to {typeof(EventTelemetry).FullName} from {typeof(TelemetryEvent).FullName}");
 
             if (typeof(TFrom) == typeof(TimedTelemetryEvent) && typeof(TTo) != typeof(EventTelemetry))
@@ -112,8 +112,16 @@
 
                         if (exceptionEvent.SimplifyStackTrace)
                         {
-                            var stackTrace = StackTraceHelper.SimplifyStackTrace(exceptionTelemetry.Exception);
-                            exceptionTelemetry.SetParsedStack(stackTrace.ToArray());
+                            try
+                            {
+                                var stackTrace = StackTraceHelper.SimplifyStackTrace(exceptionTelemetry.Exception);
+                                exceptionTelemetry.SetParsedStack(stackTrace.ToArray());
+                            }
+                            catch (Exception ex)
+                            {
+                                // Preserve the original stack trace and add some info about the problem
+                                exceptionTelemetry.Properties["SimplifyStackTraceFailed"] = ex.Message;
+                            }
                         }
                     }
 

--- a/src/Eshopworld.Telemetry/ConvertEvent.cs
+++ b/src/Eshopworld.Telemetry/ConvertEvent.cs
@@ -119,8 +119,9 @@
                             }
                             catch (Exception ex)
                             {
-                                // Preserve the original stack trace and add some info about the problem
+                                // Preserve the original stack trace append some info about the problem. Report the problem to the internal stream.
                                 exceptionTelemetry.Properties["SimplifyStackTraceFailed"] = ex.Message;
+                                BigBrother.InternalStream.OnNext(ex.ToExceptionEvent<SimplifiedExceptionEvent>());
                             }
                         }
                     }
@@ -134,6 +135,16 @@
 
                     break;
             }
+        }
+
+        internal class SimplifiedExceptionEvent : ExceptionEvent
+        {
+            public SimplifiedExceptionEvent(Exception exception)
+                : base(exception)
+            {
+            }
+
+            public override bool SimplifyStackTrace => false; // Simplification failed so do not use it to simplify this stack trace
         }
     }
 }


### PR DESCRIPTION
Any problem in the stock trace simplification code should not prevent the original exception from being logged.