### PR TITLE
Fixed an exception simplification bug.

### DIFF
--- a/src/Eshopworld.Telemetry/ConvertEvent.cs
+++ b/src/Eshopworld.Telemetry/ConvertEvent.cs
@@ -110,7 +110,7 @@
                         exceptionTelemetry.Message = exceptionEvent.Exception.Message;
                         exceptionTelemetry.Exception = exceptionEvent.Exception;
 
-                        if (exceptionEvent.SimplifyStackTrace)
+                        if (exceptionEvent.SimplifyStackTrace && StackTraceHelper.IsStackSimplificationAvailable)
                         {
                             try
                             {

--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>2.1.3</Version>
-    <PackageReleaseNotes>Declaring friendship to the snkrs control tower.</PackageReleaseNotes>
+    <Version>2.1.4</Version>
+    <PackageReleaseNotes>Fixed logging exceptions on .Net Framework.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -11,7 +11,7 @@
     <PackageId>Eshopworld.Telemetry</PackageId>
     <Title>Eshopworld.Telemetry</Title>
     <Authors>David Rodrigues, Oisin Haken, David Guerin, Artur Zgodzinski</Authors>
-    <Copyright>Copyright eShopWorld 2018</Copyright>
+    <Copyright>Copyright eShopWorld 2019</Copyright>
     <Description>eShopWorld common telemetry application insights</Description>
     <PackageLicenseUrl>https://github.com/eShopWorld/telemetry/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/eShopWorld/telemetry</PackageProjectUrl>

--- a/src/Eshopworld.Telemetry/StackTraceHelper.cs
+++ b/src/Eshopworld.Telemetry/StackTraceHelper.cs
@@ -11,7 +11,12 @@
         /// <summary>
         /// The attribute which marks methods and classes which can be omitted from the stock trace of a logged exception.
         /// </summary>
+        /// <remarks>
+        /// It's not available in all .Net runtimes.
+        /// </remarks>
         private static readonly Type StackTraceHiddenAttributeType = typeof(Attribute).Assembly.GetType("System.Diagnostics.StackTraceHiddenAttribute");
+
+        public static bool IsStackSimplificationAvailable => StackTraceHiddenAttributeType != null;
 
         public static IEnumerable<StackFrame> SimplifyStackTrace(Exception ex)
         {
@@ -57,7 +62,9 @@
 
         private static bool ShowInStackTrace(MethodBase mb)
         {
-            return !(mb.IsDefined(StackTraceHiddenAttributeType) || (mb.DeclaringType?.IsDefined(StackTraceHiddenAttributeType) ?? false));
+            return StackTraceHiddenAttributeType == null
+                || !(mb.IsDefined(StackTraceHiddenAttributeType)
+                || (mb.DeclaringType?.IsDefined(StackTraceHiddenAttributeType) ?? false));
         }
 
         private class FilteredStackFrame : StackFrame

--- a/src/Tests/Eshopworld.Telemetry.Tests/StackTraceHelperTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/StackTraceHelperTest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Eshopworld.Telemetry;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Xunit;
+
+public class StackTraceHelperTest
+{
+    [Fact, IsUnit]
+    public void StackSimplificationIsAvailable()
+    {
+        StackTraceHelper.IsStackSimplificationAvailable.Should().BeTrue();
+    }
+
+    [Fact, IsUnit]
+    public void StackIsSimplified()
+    {
+        Func<Task> call = OuterMethodAsync;
+        Exception ex = call.Should().Throw<InvalidOperationException>().Which;
+
+        var originalStack = new StackTrace(ex).GetFrames();
+        var simplifiedStack = StackTraceHelper.SimplifyStackTrace(ex);
+        simplifiedStack.Count().Should().BeLessThan(originalStack.Length);
+    }
+
+
+    private async Task OuterMethodAsync()
+    {
+        await InnerMethodAsync();
+    }
+
+    private async Task InnerMethodAsync()
+    {
+        await Task.Yield();
+
+        throw new InvalidOperationException("test");
+    }
+}


### PR DESCRIPTION
The .Net Framework does not support exception trace simplification. It's only available on .Net Core. The fix makes this functionality dependent on runtime support.