### PR TITLE
Drop and create a table on each test run

### DIFF
--- a/src/Eshopworld.Telemetry/KustoExtensions.cs
+++ b/src/Eshopworld.Telemetry/KustoExtensions.cs
@@ -55,7 +55,7 @@
                 client.ExecuteControlCommand(command);
                 return mappingName;
             }
-            catch (KustoBadRequestException ex) when (ex.ErrorMessage.Contains("'JsonMappingPersistent' was not found"))
+            catch (KustoBadRequestException ex) when (ex.ErrorMessage.Contains("MappingPersistent' was not found"))
             {
                 // soak
             }


### PR DESCRIPTION
MS changed exception message and removed "Json" prefix so we were not creating a new table successfully. 
Test case updated to drop the table after each run, we will be able to see now if this starts failing again if exception message gets changed again. 