### PR TITLE
Added instrumentation to Kusto integration and async'ed all Kusto calls

### DIFF
--- a/src/Eshopworld.Telemetry.Benchmark/Eshopworld.Telemetry.Benchmark.csproj
+++ b/src/Eshopworld.Telemetry.Benchmark/Eshopworld.Telemetry.Benchmark.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="benchmarkdotnet" Version="0.11.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Eshopworld.Telemetry\Eshopworld.Telemetry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Eshopworld.Telemetry.Benchmark/Program.cs
+++ b/src/Eshopworld.Telemetry.Benchmark/Program.cs
@@ -40,7 +40,7 @@
             [Benchmark]
             public void One_NoCheck_Direct()
             {
-                bb.HandleKustoEvent(new KustoTestEvent());
+                bb.HandleKustoEvent(new KustoBenchmarkEvent());
             }
 
             [Benchmark]
@@ -49,7 +49,7 @@
                 var tasks = new List<Task>();
                 for (int i = 0; i < 50; i++)
                 {
-                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoTestEvent()); }));
+                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoBenchmarkEvent()); }));
                 }
 
                 Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -61,16 +61,16 @@
                 var tasks = new List<Task>();
                 for (int i = 0; i < 200; i++)
                 {
-                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoTestEvent()); }));
+                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoBenchmarkEvent()); }));
                 }
 
                 Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();
             }
         }
 
-        public class KustoTestEvent : DomainEvent
+        public class KustoBenchmarkEvent : DomainEvent
         {
-            public KustoTestEvent()
+            public KustoBenchmarkEvent()
             {
                 Id = Guid.NewGuid();
                 SomeInt = new Random().Next(100);
@@ -87,6 +87,8 @@
             public string SomeStringOne { get; set; }
 
             public string SomeStringTwo { get; set; }
+
+            public string BlaBla { set; get; }
 
             public DateTime SomeDateTime { get; set; }
 

--- a/src/Eshopworld.Telemetry.Benchmark/Program.cs
+++ b/src/Eshopworld.Telemetry.Benchmark/Program.cs
@@ -40,7 +40,7 @@
             [Benchmark]
             public void One_NoCheck_Direct()
             {
-                bb.HandleKustoEvent(new KustoBenchmarkEvent());
+                bb.HandleKustoEvent(new KustoBenchmarkEvent()).ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
             [Benchmark]
@@ -49,7 +49,7 @@
                 var tasks = new List<Task>();
                 for (int i = 0; i < 50; i++)
                 {
-                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoBenchmarkEvent()); }));
+                    tasks.Add(bb.HandleKustoEvent(new KustoBenchmarkEvent()));
                 }
 
                 Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -61,7 +61,7 @@
                 var tasks = new List<Task>();
                 for (int i = 0; i < 200; i++)
                 {
-                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoBenchmarkEvent()); }));
+                    tasks.Add(bb.HandleKustoEvent(new KustoBenchmarkEvent()));
                 }
 
                 Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/Eshopworld.Telemetry.Benchmark/Program.cs
+++ b/src/Eshopworld.Telemetry.Benchmark/Program.cs
@@ -5,9 +5,7 @@
     using System.Threading.Tasks;
     using BenchmarkDotNet.Attributes;
     using BenchmarkDotNet.Configs;
-    using BenchmarkDotNet.Jobs;
     using BenchmarkDotNet.Running;
-    using BenchmarkDotNet.Validators;
     using Eshopworld.Core;
 
     public class Program

--- a/src/Eshopworld.Telemetry.Benchmark/Program.cs
+++ b/src/Eshopworld.Telemetry.Benchmark/Program.cs
@@ -1,0 +1,101 @@
+﻿namespace Eshopworld.Telemetry.Benchmark
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Jobs;
+    using BenchmarkDotNet.Running;
+    using BenchmarkDotNet.Validators;
+    using Eshopworld.Core;
+
+    public class Program
+    {
+        [CoreJob]
+        [Config(typeof(Config))]
+        public class KustoBenchmark
+        {
+            private class Config : ManualConfig
+            {
+                public Config()
+                {
+                    Options |= ConfigOptions.DisableOptimizationsValidator;
+                }
+            }
+
+            private BigBrother bb;
+
+            public KustoBenchmark()
+            {
+                var kustoName = Environment.GetEnvironmentVariable("kusto_name", EnvironmentVariableTarget.Machine);
+                var kustoLocation = Environment.GetEnvironmentVariable("kusto_location", EnvironmentVariableTarget.Machine);
+                var kustoDatabase = Environment.GetEnvironmentVariable("kusto_database", EnvironmentVariableTarget.Machine);
+                var kustoTenantId = Environment.GetEnvironmentVariable("kusto_tenant_id", EnvironmentVariableTarget.Machine);
+
+                bb = new BigBrother("", "");
+                bb.UseKusto(kustoName, kustoLocation, kustoDatabase, kustoTenantId);
+            }
+
+            [Benchmark]
+            public void One_NoCheck_Direct()
+            {
+                bb.HandleKustoEvent(new KustoTestEvent());
+            }
+
+            [Benchmark]
+            public void Fifty_NoCheck_Direct()
+            {
+                var tasks = new List<Task>();
+                for (int i = 0; i < 50; i++)
+                {
+                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoTestEvent()); }));
+                }
+
+                Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+
+            [Benchmark]
+            public void TwoHundred_NoCheck_Direct()
+            {
+                var tasks = new List<Task>();
+                for (int i = 0; i < 200; i++)
+                {
+                    tasks.Add(Task.Factory.StartNew(() => { bb.HandleKustoEvent(new KustoTestEvent()); }));
+                }
+
+                Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+        }
+
+        public class KustoTestEvent : DomainEvent
+        {
+            public KustoTestEvent()
+            {
+                Id = Guid.NewGuid();
+                SomeInt = new Random().Next(100);
+                SomeStringOne = Guid.NewGuid().ToString();
+                SomeStringTwo = Guid.NewGuid().ToString();
+                SomeDateTime = DateTime.Now;
+                SomeTimeSpan = TimeSpan.FromMinutes(new Random().Next(60));
+            }
+
+            public Guid Id { get; set; }
+
+            public int SomeInt { get; set; }
+
+            public string SomeStringOne { get; set; }
+
+            public string SomeStringTwo { get; set; }
+
+            public DateTime SomeDateTime { get; set; }
+
+            public TimeSpan SomeTimeSpan { get; set; }
+        }
+
+        public static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<KustoBenchmark>();
+        }
+    }
+}

--- a/src/Eshopworld.Telemetry.sln
+++ b/src/Eshopworld.Telemetry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29201.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2BD76580-1A5B-4B74-8E60-9493016BFDC5}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,6 +13,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eshopworld.Telemetry", "Eshopworld.Telemetry\Eshopworld.Telemetry.csproj", "{365A1306-F9A5-45F2-A490-E0706A7D5C93}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eshopworld.Telemetry.Tests", "Tests\Eshopworld.Telemetry.Tests\Eshopworld.Telemetry.Tests.csproj", "{FC8A017C-51CF-44F4-9B8F-663162263031}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eshopworld.Telemetry.Benchmark", "Eshopworld.Telemetry.Benchmark\Eshopworld.Telemetry.Benchmark.csproj", "{F0CFBC86-AC83-4269-9EB7-B63305356292}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,6 +30,10 @@ Global
 		{FC8A017C-51CF-44F4-9B8F-663162263031}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC8A017C-51CF-44F4-9B8F-663162263031}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC8A017C-51CF-44F4-9B8F-663162263031}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0CFBC86-AC83-4269-9EB7-B63305356292}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0CFBC86-AC83-4269-9EB7-B63305356292}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0CFBC86-AC83-4269-9EB7-B63305356292}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0CFBC86-AC83-4269-9EB7-B63305356292}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Eshopworld.Telemetry/AssemblyInfo.cs
+++ b/src/Eshopworld.Telemetry/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Eshopworld.Telemetry.Tests")]
+[assembly: InternalsVisibleTo("Eshopworld.Telemetry.Benchmark")]
+
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 [assembly: InternalsVisibleTo("Nike.Snkrs.WatchDogActor")]

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -521,11 +521,11 @@
                     writer.Flush();
                     stream.Seek(0, SeekOrigin.Begin);
 
-                    var startTime = DateTime.Now;
+                    var startTime = DateTime.UtcNow;
 
                     await KustoIngestClient.IngestFromStreamAsync(stream, ingestProps, true);
 
-                    KustoIngestionTimeMetric.TrackValue(DateTime.Now.Subtract(startTime).TotalMilliseconds);
+                    KustoIngestionTimeMetric.TrackValue(DateTime.UtcNow.Subtract(startTime).TotalMilliseconds);
                 }
             }
             catch (Exception e)

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -495,8 +495,6 @@
                     {
                         ingestProps = new KustoQueuedIngestionProperties(KustoDbName, "Unknown");
 
-                        ingestProps = KustoMappings[eventType];
-
                         ingestProps.TableName = KustoAdminClient.GenerateTableFromType(eventType);
                         ingestProps.JSONMappingReference = KustoAdminClient.GenerateTableJsonMappingFromType(eventType);
                         ingestProps.ReportLevel = IngestionReportLevel.FailuresOnly;

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -261,6 +261,9 @@
             return UseKusto(kustoEngineName, kustoEngineLocation, kustoDb, tenantId, null);
         }
 
+        /// <remarks>
+        /// This will be documented later, because for now I'm not changing the interface for BigBrother to avoid breaking changes overlapping with v3.
+        /// </remarks>
         public IBigBrother UseKusto(string kustoEngineName, string kustoEngineLocation, string kustoDb, string tenantId, IKustoIngestClient client)
         {
             try

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -297,14 +297,7 @@
                 }
                 else
                 {
-                    KustoIngestClient = KustoIngestFactory.CreateDirectIngestClient(
-                        new KustoConnectionStringBuilder(kustoUri)
-                        {
-                            FederatedSecurity = true,
-                            InitialCatalog = KustoDbName,
-                            Authority = tenantId,
-                            ApplicationToken = token,
-                        });
+                    KustoIngestClient = client;
                 }
 
                 SetupKustoSubscription();

--- a/src/Eshopworld.Telemetry/ConvertEvent.cs
+++ b/src/Eshopworld.Telemetry/ConvertEvent.cs
@@ -23,7 +23,7 @@
         /// This exists to make the class testable and to allow control over the "Now" during a test.
         /// </summary>
         [NotNull]
-        internal Func<DateTime> Now = () => DateTime.Now;
+        internal Func<DateTime> Now = () => DateTime.UtcNow;
 
         /// <summary>
         /// Initializes a new instance of <see cref="ConvertEvent{TFrom,TTo}"/>.

--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>2.1.4</Version>
-    <PackageReleaseNotes>Fixed logging exceptions on .Net Framework.</PackageReleaseNotes>
+    <Version>2.2.0-beta1</Version>
+    <PackageReleaseNotes>First set of improvements for the Kusto Integration.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>True</IsPackable>

--- a/src/Eshopworld.Telemetry/KustoExtensions.cs
+++ b/src/Eshopworld.Telemetry/KustoExtensions.cs
@@ -33,7 +33,7 @@
             
             if (tables.Contains(tableName)) return tableName;
 
-            var columns = type.GetProperties().Select(property => new Tuple<string, string>(property.Name, property.PropertyType.FullName)).ToList();
+            var columns = type.GetProperties().Select(property => Tuple.Create(property.Name, property.PropertyType.FullName)).ToList();
             command = CslCommandGenerator.GenerateTableCreateCommand(tableName, columns);
             client.ExecuteControlCommand(command);
 

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
@@ -21,6 +21,7 @@ public class BigBrotherUseKustoTest
     private readonly string _kustoTenantId;
 
     private readonly ICslQueryProvider _kustoQueryClient;
+    private readonly ICslAdminProvider _kustoAdminClient;
 
     public BigBrotherUseKustoTest()
     {
@@ -33,16 +34,24 @@ public class BigBrotherUseKustoTest
         {
             var kustoUri = $"https://{_kustoName}.{_kustoLocation}.kusto.windows.net";
             var token = new AzureServiceTokenProvider().GetAccessTokenAsync(kustoUri, string.Empty).Result;
-
-            _kustoQueryClient = KustoClientFactory.CreateCslQueryProvider(
+            var kustoConnectionString =
                 new KustoConnectionStringBuilder(kustoUri)
                 {
                     FederatedSecurity = true,
                     InitialCatalog = _kustoDatabase,
                     Authority = _kustoTenantId,
                     ApplicationToken = token
-                });
+                };
+
+            _kustoQueryClient = KustoClientFactory.CreateCslQueryProvider(kustoConnectionString);
+            _kustoAdminClient = KustoClientFactory.CreateCslAdminProvider(kustoConnectionString);
         }
+    }
+
+    [Fact, IsLayer1]
+    public void Foo()
+    {
+        _kustoAdminClient.GenerateTableJsonMappingFromType(typeof(KustoTestEvent));
     }
 
     [Fact, IsLayer1]

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
@@ -49,17 +49,11 @@ public class BigBrotherUseKustoTest
     }
 
     [Fact, IsLayer1]
-    public void Foo()
-    {
-        _kustoAdminClient.GenerateTableJsonMappingFromType(typeof(KustoTestEvent));
-    }
-
-    [Fact, IsLayer1]
     public async Task Test_KustoTestEvent_StreamsToKusto()
     {
         _kustoQueryClient.Should().NotBeNull();
 
-        var bb = new BigBrother("", "");
+        var bb = new BigBrother("e7b35726-ec5f-4f95-8a00-628e7546de2a", "e7b35726-ec5f-4f95-8a00-628e7546de2a");
         bb.UseKusto(_kustoName, _kustoLocation, _kustoDatabase, _kustoTenantId);
 
         var evt = new KustoTestEvent();
@@ -90,7 +84,7 @@ public class BigBrotherUseKustoTest
         var bb = new Mock<BigBrother>();
         bb.Setup(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>())).Verifiable();
 
-        bb.Object.SetupKustoSubscription(null);
+        bb.Object.SetupKustoSubscription();
         bb.Object.Publish(new Exception().ToExceptionEvent());
 
         bb.Verify(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>()), Times.Never);
@@ -102,7 +96,7 @@ public class BigBrotherUseKustoTest
         var bb = new Mock<BigBrother>();
         bb.Setup(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>())).Verifiable();
 
-        bb.Object.SetupKustoSubscription(null);
+        bb.Object.SetupKustoSubscription();
         bb.Object.Publish(new KustoTestTimedEvent());
 
         bb.Verify(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>()), Times.Never);
@@ -114,7 +108,7 @@ public class BigBrotherUseKustoTest
         var bb = new Mock<BigBrother>();
         bb.Setup(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>())).Verifiable();
 
-        bb.Object.SetupKustoSubscription(null);
+        bb.Object.SetupKustoSubscription();
         bb.Object.Publish(new KustoTestMetricEvent());
 
         bb.Verify(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>()), Times.Never);

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
@@ -53,7 +53,7 @@ public class BigBrotherUseKustoTest
     {
         _kustoQueryClient.Should().NotBeNull();
 
-        var bb = new BigBrother("e7b35726-ec5f-4f95-8a00-628e7546de2a", "e7b35726-ec5f-4f95-8a00-628e7546de2a");
+        var bb = new BigBrother("", "");
         bb.UseKusto(_kustoName, _kustoLocation, _kustoDatabase, _kustoTenantId);
 
         var evt = new KustoTestEvent();

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
@@ -90,7 +90,7 @@ public class BigBrotherUseKustoTest
         var bb = new Mock<BigBrother>();
         bb.Setup(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>())).Verifiable();
 
-        bb.Object.SetupKustoSubscription();
+        bb.Object.SetupKustoSubscription(null);
         bb.Object.Publish(new Exception().ToExceptionEvent());
 
         bb.Verify(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>()), Times.Never);
@@ -102,7 +102,7 @@ public class BigBrotherUseKustoTest
         var bb = new Mock<BigBrother>();
         bb.Setup(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>())).Verifiable();
 
-        bb.Object.SetupKustoSubscription();
+        bb.Object.SetupKustoSubscription(null);
         bb.Object.Publish(new KustoTestTimedEvent());
 
         bb.Verify(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>()), Times.Never);
@@ -114,7 +114,7 @@ public class BigBrotherUseKustoTest
         var bb = new Mock<BigBrother>();
         bb.Setup(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>())).Verifiable();
 
-        bb.Object.SetupKustoSubscription();
+        bb.Object.SetupKustoSubscription(null);
         bb.Object.Publish(new KustoTestMetricEvent());
 
         bb.Verify(x => x.HandleKustoEvent(It.IsAny<TelemetryEvent>()), Times.Never);


### PR DESCRIPTION
Added instrumentation to the Kusto handling code, and async'ed everything in a non-blocking way.

Also added a benchmark to the Kusto code, so that baselines could be easily replayed throughout development of the overall Kusto integration.

Fixes [AB#25911](https://dev.azure.com/eshopworld/ae94cf4d-b3a2-4dfd-9ae9-8e2a9ab5f6cf/_workitems/edit/25911)