### PR TITLE
Update test project dependency

### DIFF
--- a/src/Tests/Eshopworld.Telemetry.Tests/Eshopworld.Telemetry.Tests.csproj
+++ b/src/Tests/Eshopworld.Telemetry.Tests/Eshopworld.Telemetry.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.0" />
+    <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />


### PR DESCRIPTION
This only updates eshopworld.tests.core dependencies for the test project.
There is no plan to release an update package once this is merged.