### PR TITLE
fix telemetry set up under asp.net core 3.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -20,9 +20,9 @@ steps:
     workingDirectory: src
 
 - task: NuGetToolInstaller@1
-  displayName: 'use nuget 4.X'
+  displayName: 'use nuget 5.X'
   inputs:
-    versionSpec: 4.X
+    versionSpec: 5.X
     checkLatest: true
 
 - task: NuGetCommand@2

--- a/build.yaml
+++ b/build.yaml
@@ -37,6 +37,7 @@ steps:
   displayName: 'prepare variables'
 
 - task: SonarSource.sonarcloud.14d9cde6-c1da-4d55-aa01-2965cd301255.SonarCloudPrepare@1
+  enabled: false
   displayName: 'Prepare analysis on SonarCloud'
   inputs:
     SonarCloud: 'sonarcloud-eshopworld'
@@ -69,9 +70,11 @@ steps:
     diagnosticsEnabled: True
 
 - task: SonarSource.sonarcloud.ce096e50-6155-4de8-8800-4221aaeed4a1.SonarCloudAnalyze@1
+  enabled: false
   displayName: 'Run Code Analysis'
 
 - task: SonarSource.sonarcloud.38b27399-a642-40af-bb7d-9971f69712e8.SonarCloudPublish@1
+  enabled: false
   displayName: 'Publish Analysis Result'
 
 - task: VSBuild@1

--- a/src/Eshopworld.Telemetry.Benchmark/Program.cs
+++ b/src/Eshopworld.Telemetry.Benchmark/Program.cs
@@ -32,7 +32,7 @@ namespace Eshopworld.Telemetry.Benchmark
                 var kustoDatabase = Environment.GetEnvironmentVariable("kusto_database");
                 var kustoTenantId = Environment.GetEnvironmentVariable("kusto_tenant_id");
 
-                _bbForHandle = new BigBrother("", "");
+                _bbForHandle = BigBrother.CreateDefault("", "");
                 _bbForHandle.UseKusto()
                             .WithCluster(kustoName, kustoLocation, kustoDatabase, kustoTenantId)
                             .RegisterType<KustoBenchmarkEvent>()

--- a/src/Eshopworld.Telemetry/BigBrother.cs
+++ b/src/Eshopworld.Telemetry/BigBrother.cs
@@ -25,6 +25,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Metrics;
 using Microsoft.Azure.Services.AppAuthentication;
 using Newtonsoft.Json;
+using Eshopworld.Telemetry.Initializers;
 
 namespace Eshopworld.Telemetry
 {
@@ -154,14 +155,26 @@ namespace Eshopworld.Telemetry
         /// </summary>
         /// <param name="aiKey">The application's Application Insights instrumentation key.</param>
         /// <param name="internalKey">The devops internal telemetry Application Insights instrumentation key.</param>
+        [Obsolete("Use constructor with TelemetryClient supplied via DI as AI SDK for ASP.NET Core maintains fully fleshed out telemetry configuration instance - see https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 . This constructor uses default config which references only OperationCorrelationTelemetryInitializer")]
         public BigBrother(string aiKey, string internalKey)
         {
-            TelemetryClient = new TelemetryClient(new TelemetryConfiguration
-            {
-                InstrumentationKey = aiKey,
-            });
+            TelemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault()){InstrumentationKey = aiKey};
             InternalClient.InstrumentationKey = internalKey;
             SetupSubscriptions();
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="BigBrother"/>.
+        ///     Used to leverage an existing <see cref="TelemetryClient"/> to track correlation.
+        ///     This constructor does a bit of work, so if you're mocking this, mock the <see cref="IBigBrother"/> contract instead.
+        /// </summary>
+        /// <param name="client">The application's existing <see cref="TelemetryClient"/>.</param>
+        /// <param name="aiKey">The application's Application Insights instrumentation key, overwrites any instrumentation set on telemetry client directly</param>
+        /// <param name="internalKey">The devops internal telemetry Application Insights instrumentation key.</param>
+        public BigBrother(TelemetryClient client, string aiKey, string internalKey):this(client, internalKey)
+        {
+            TelemetryClient.InstrumentationKey = aiKey;
         }
 
         /// <summary>
@@ -189,6 +202,23 @@ namespace Eshopworld.Telemetry
             telemetryObservable = TelemetryStream.AsObservable();
             telemetryObserver = TelemetryStream.AsObserver();
             internalObservable = InternalStream.AsObservable();
+        }
+
+        /// <summary>
+        /// ReSharper disable once CommentTypo
+        /// creates default <see cref="BigBrother"/> instance with <see cref="OperationCorrelationTelemetryInitializer"/> and <see cref="EnvironmentDetailsTelemetryInitializer"/> initializers
+        ///
+        /// the expected usage is exception happening prior to DI container established
+        /// </summary>
+        /// <param name="aiKey">The application's Application Insights instrumentation key</param>
+        /// <param name="internalKey">The devops internal telemetry Application Insights instrumentation key.</param>
+        /// <returns><see cref="BigBrother"/> default instance</returns>
+        public static BigBrother CreateDefault(string aiKey, string internalKey)
+        {
+            var telConfig = TelemetryConfiguration.CreateDefault();
+            telConfig.TelemetryInitializers.Add(new EnvironmentDetailsTelemetryInitializer());
+            var telClient = new TelemetryClient(telConfig) { InstrumentationKey = aiKey };
+            return new BigBrother(telClient, aiKey, internalKey);
         }
 
         /// <summary>

--- a/src/Eshopworld.Telemetry/Configuration/TelemetryModule.cs
+++ b/src/Eshopworld.Telemetry/Configuration/TelemetryModule.cs
@@ -1,13 +1,14 @@
 ﻿using System.Collections.Generic;
 using Autofac;
 using Eshopworld.Core;
+using Eshopworld.Telemetry.Initializers;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Eshopworld.Telemetry.Configuration
 {
     /// <summary>
-    /// Registers general Application Inisghts telemetry components.
+    /// Registers general Application Insights telemetry components.
     /// </summary>
     public class TelemetryModule : Module
     {
@@ -17,7 +18,7 @@ namespace Eshopworld.Telemetry.Configuration
             {
                 var telemetryClient = c.Resolve<TelemetryClient>();
                 var telemetrySettings = c.Resolve<TelemetrySettings>();
-                var bb = new BigBrother(telemetryClient, telemetrySettings.InternalKey);
+                var bb = new BigBrother(telemetryClient, telemetrySettings.InstrumentationKey, telemetrySettings.InternalKey);
 
                 var bigBrotherInitializers = c.Resolve<IEnumerable<IBigBrotherInitializer>>();
                 foreach (var initializer in bigBrotherInitializers)
@@ -30,6 +31,7 @@ namespace Eshopworld.Telemetry.Configuration
             .SingleInstance();
 
             builder.RegisterInstance(LogicalCallTelemetryInitializer.Instance).As<ITelemetryInitializer>();
+            builder.RegisterInstance(new EnvironmentDetailsTelemetryInitializer()).As<ITelemetryInitializer>();
             builder.RegisterType<BigBrotherEventsPublisherInitializer>().As<IBigBrotherInitializer>();
         }
     }

--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>3.1.0</Version>
-    <PackageReleaseNotes>netstandard2.1, stateful actor telemetry and Kusto support.</PackageReleaseNotes>
+    <Version>3.1.1</Version>
+    <PackageReleaseNotes>AI correlation issue fix, changes to BB constructor, providing default configuration BB instance, changes to TelemetryModule</PackageReleaseNotes>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>True</IsPackable>
 

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherTest.cs
@@ -25,7 +25,7 @@ public class BigBrotherTest
         [Fact, IsDev]
         public void EntryPoint_PushEvent()
         {
-            IBigBrother bb = new BigBrother(DevKey, DevKey).DeveloperMode();
+            IBigBrother bb = BigBrother.CreateDefault(DevKey, DevKey).DeveloperMode();
 
             bb.Publish(new TestTelemetryEvent());
             bb.Flush();
@@ -35,7 +35,7 @@ public class BigBrotherTest
         public void EntryPoint_PushException()
         {
             const string message = "KABOOM!!!";
-            IBigBrother bb = new BigBrother(DevKey, DevKey).DeveloperMode();
+            IBigBrother bb = BigBrother.CreateDefault(DevKey, DevKey).DeveloperMode();
 
             try
             {
@@ -51,7 +51,7 @@ public class BigBrotherTest
         [Fact, IsDev]
         public void EntryPoint_PushTimed()
         {
-            IBigBrother bb = new BigBrother(DevKey, DevKey).DeveloperMode();
+            IBigBrother bb = BigBrother.CreateDefault(DevKey, DevKey).DeveloperMode();
 
             bb.Publish(new TestTimedEvent());
             bb.Flush();
@@ -60,7 +60,7 @@ public class BigBrotherTest
         [Fact, IsDev]
         public void EntryPoint_PushAnonymous()
         {
-            IBigBrother bb = new BigBrother(DevKey, DevKey).DeveloperMode();
+            IBigBrother bb = BigBrother.CreateDefault(DevKey, DevKey).DeveloperMode();
 
             bb.Publish(new
             {
@@ -153,7 +153,7 @@ public class BigBrotherTest
             var tasks = new List<Task>();
             for (var x = 0; x < 10; x++)
             {
-                tasks.Add(Task.Run(()=> new BigBrother("blah", "blah")));
+                tasks.Add(Task.Run(()=> BigBrother.CreateDefault("blah", "blah")));
             }
 
             //this will blow up in V2
@@ -250,7 +250,7 @@ public class BigBrotherTest
 
                                             Task.Factory.StartNew(() =>
                                             {
-                                                var brother = new BigBrother("blah", "blah"); // to initialize internal Rx subscriptions
+                                                var brother = BigBrother.CreateDefault("blah", "blah"); // to initialize internal Rx subscriptions
                                                 Task.Delay(TimeSpan.FromSeconds(3));
                                                 BigBrother.Write(new ExceptionEvent(new Exception(exceptionMessage)));
                                             });

--- a/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/BigBrotherUseKustoTest.cs
@@ -60,7 +60,7 @@ namespace Eshopworld.Telemetry.Tests
         {
             _kustoQueryClient.Should().NotBeNull();
 
-            var bb = new BigBrother("", "");
+            var bb = BigBrother.CreateDefault("", "");
 
             var builder = bb.UseKusto()
                 .WithCluster(_kustoName, _kustoLocation, _kustoDatabase, _kustoTenantId);

--- a/src/Tests/Eshopworld.Telemetry.Tests/Eshopworld.Telemetry.Tests.csproj
+++ b/src/Tests/Eshopworld.Telemetry.Tests/Eshopworld.Telemetry.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.51" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="polly" Version="7.2.0" />

--- a/src/Tests/Eshopworld.Telemetry.Tests/MessagingConfigurationExtensionsTest.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/MessagingConfigurationExtensionsTest.cs
@@ -11,7 +11,7 @@ public class MessagingConfigurationExtensionsTest
     [Fact, IsUnit]
     public void Test_Publish_UsesTopics_WhenSetup()
     {
-        var bb = new BigBrother("", "");
+        var bb = BigBrother.CreateDefault("", "");
         bb.TelemetrySubscriptions.Clear(); // disable normal telemetry
         var dEvent = new TestDomainEvent();
 
@@ -27,7 +27,7 @@ public class MessagingConfigurationExtensionsTest
     [Fact, IsUnit]
     public void Test_Publish_NoTopics_WhenNotSetup()
     {
-        var bb = new BigBrother("", "");
+        var bb = BigBrother.CreateDefault("", "");
         bb.TelemetrySubscriptions.Clear(); // disable normal telemetry
         var dEvent = new TestDomainEvent();
 
@@ -41,7 +41,7 @@ public class MessagingConfigurationExtensionsTest
     [Fact, IsUnit]
     public void Test_Publish_WontSendNonDomainEvents_ToTopics()
     {
-        var bb = new BigBrother("", "");
+        var bb = BigBrother.CreateDefault("", "");
         bb.TelemetrySubscriptions.Clear(); // disable normal telemetry
         var dEvent = new TestTimedEvent();
 


### PR DESCRIPTION
Issue was reported for AI correlation not being present

the issue was investigated and revolves around how the BB was instantiated - new telemetry config object was constructured which would have no initializers (bar the very basic one) 

as per https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152

the fix is to rely on proper DI to inject telemetry client and telemetry config (which would be set up under ASP.NET core context via provided service extension methods)

**the breaking change is** that the standard BB constructor is now marked as obsolete as it can only target the dummy default telemetry configuration

we also need to support the flow of BB usage **outside** of DI - to capture any exceptions happening during DI creation - startup time

I tied this by following AI SDK principles and provide default BB instance on top of default telemetry config and providing default big brother on top of that for such use cases

I also noticed one custom telemetry initializer not added to the telemetry module