### PR TITLE
Filter out health probes through HEAD requests

### DIFF
--- a/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
+++ b/src/Eshopworld.Telemetry/Eshopworld.Telemetry.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>3.1.2</Version>
-    <PackageReleaseNotes>Add ProbeTelemetryProcessor to filter out health probes</PackageReleaseNotes>
+    <Version>3.1.3</Version>
+    <PackageReleaseNotes>Add ProbeTelemetryProcessor to filter out health probes received through HEAD &amp; GET requests.</PackageReleaseNotes>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>True</IsPackable>
 
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath=""/>
+    <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Eshopworld.Telemetry/Processors/SuccessfulProbeFilterCriteria.cs
+++ b/src/Eshopworld.Telemetry/Processors/SuccessfulProbeFilterCriteria.cs
@@ -17,8 +17,11 @@ namespace Eshopworld.Telemetry.Processors
 
             if (request == null) return false;
 
-            return request.ResponseCode == "200" &&
-                   request.Name.StartsWith("GET Probe/", StringComparison.OrdinalIgnoreCase);
+            return
+                request.ResponseCode == "200" && (
+                    request.Name.StartsWith("GET Probe/", StringComparison.OrdinalIgnoreCase) ||
+                    request.Name.StartsWith("HEAD Probe/", StringComparison.OrdinalIgnoreCase)
+                );
         }
     }
 }

--- a/src/Tests/Eshopworld.Telemetry.Tests/SuccessfulProbeFilterCriteriaTests.cs
+++ b/src/Tests/Eshopworld.Telemetry.Tests/SuccessfulProbeFilterCriteriaTests.cs
@@ -32,6 +32,13 @@ namespace Eshopworld.Telemetry.Tests
         [InlineData("200", "PUT Probe/Probe", false)]
         [InlineData("200", "GET Entity/Probe", false)]
         [InlineData("200", "GET ProbeTest/Probe", false)]
+        [InlineData("200", "HEAD Probe/Probe", true)]
+        [InlineData("200", "head Probe/Probe", true)]
+        [InlineData("200", "HEAD probe/Probe", true)]
+        [InlineData("200", "HEAD Probe/ProbeUserContext", true)]
+        [InlineData("400", "HEAD Probe/Probe", false)]
+        [InlineData("200", "HEAD Entity/Probe", false)]
+        [InlineData("200", "HEAD ProbeTest/Probe", false)]
         public void Test(string responseCode, string actionName, bool shouldFilter)
         {
             // Arrange


### PR DESCRIPTION
As a ESW developer
I would like to be able to configure Telemetry
so successful health probe requests are not logged in AI